### PR TITLE
.github: Delegate repo permissions to teams, instead of individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,8 @@
 # the repo. Unless a later match takes precedence,
 # the following users/teams will be requested for
 # review when someone opens a pull request.
-# TODO(.github): Individual maintainers should be managed as a team
-* @todogroup/steering-committee @cornelius @misappi @mkurzman @OliverFendt
+* @todogroup/outbound-oss-maintainers
 
 # Enforces admin protections for repo configuration via probot settings app.
 # ref: https://github.com/probot/settings#security-implications
-.github/settings.yml @todogroup/steering-committee
+.github/settings.yml @todogroup/outbound-oss-admins

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,26 +12,14 @@ repository:
 
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
-  - name: steering-committee
+  - name: outbound-oss-admins
     # The permission to grant the team. Can be one of:
     # * `pull` - can pull, but not push to or administer this repository.
     # * `push` - can pull and push, but not administer this repository.
     # * `admin` - can pull, push and administer this repository.
     # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
     permission: admin
-
-# Collaborators: give specific users access to this repository.
-# See https://docs.github.com/en/rest/reference/collaborators for available options
-collaborators:
-  # maintain
-  - username: misappi
+  - name: outbound-oss-maintainers
     permission: maintain
-
-  - username: cornelius
-    permission: maintain
-
-  - username: mkurzman
-    permission: maintain
-
-  - username: OliverFendt
-    permission: maintain
+  - name: outbound-oss
+    permission: triage


### PR DESCRIPTION
Fixes https://github.com/todogroup/outbound-oss/issues/53.

Signed-off-by: Stephen Augustus <foo@auggie.dev>